### PR TITLE
Using jira port in ticket url

### DIFF
--- a/jira-ticket.js
+++ b/jira-ticket.js
@@ -34,6 +34,7 @@ JiraTicket.prototype.get = function ( issueKey, callback ) {
 			url    : url.format( {
 				protocol: self.config.protocol,
 				hostname: self.config.host,
+				port: self.config.port,
 				pathname: 'browse/' + issue.key
 			} )
 		};


### PR DESCRIPTION
Bot was posting wrong URL for self-hosted jira with not standard port.